### PR TITLE
Fix Travis CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
       python: 3.8
     - os: linux
       python: 3.9
+    - os: linux
+      dist: focal
+      python: 3.10
     - os: osx
       language: generic
       env: PYTHON_BIN=python2

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ matrix:
 script:
   - $PYTHON_BIN setup.py install
   - cd ..
-  - $PYTHON_BIN -m sslpsk.test
+  - $PYTHON_BIN -m sslpsk2.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       python: 3.7
     - os: linux
       python: 3.8
+    - os: linux
+      python: 3.9
     - os: osx
       language: generic
       env: PYTHON_BIN=python2


### PR DESCRIPTION
The Travis CI build seems to be broken since the rename to `sslpsk2`, this PR should fix Travis builds and also add tests for python 3.9 and 3.10